### PR TITLE
Add configurable join/leave embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The bot will connect to Discord and begin updating the embed in the specified ch
 
 ## Configuration
 
-`config.ini` holds the settings for the bot. Below is an overview:
+`config.ini` holds the settings for the bot. Below is an overview. The new `[events]` section controls join/leave messages:
 
 ```ini
 [discord]
@@ -47,6 +47,16 @@ short_server_name = MVP
 connect_url = https://tinyurl.com/yourserver
 # ASE query port of the server (not the game port)
 port = 22005
+
+[events]
+welcome_channel = 👋🏻┊arrivers
+leave_channel = 💻┊dc-logs
+embed_color = #ff9d00
+banner_url = https://cdn.discordapp.com/attachments/1278491203905523854/1326757485356253305/MvP_banner_zoomed.jpg?ex=68387ff2&is=68372e72&hm=8c8f4b0deb6961e58d59bbf06b0ae19dddc47dceded1c431c942bd25ea1a1edd&
+welcome_title = Welcome {member.name}!
+welcome_message = {member.mention} joined the server. We now have {member_count} members!
+leave_title = {member.name} left.
+leave_message = {member.mention} left the server. We now have {member_count} members.
 ```
 
 Adjust the values to match your server. The host should be the public IP of your MTA:SA server, and the port must be its ASE port so the bot can query player information.

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -13,6 +13,7 @@ class DiscordBot(commands.Bot):
     def __init__(self, config: BotConfig) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
+        intents.members = True
         super().__init__(command_prefix='!', intents=intents)
         self.config = config
         self.embed_message = None
@@ -24,6 +25,54 @@ class DiscordBot(commands.Bot):
 
     def run_bot(self) -> None:
         super().run(self.config.token)
+
+    async def on_member_join(self, member: discord.Member) -> None:
+        channel = discord.utils.get(
+            member.guild.text_channels, name=self.config.welcome_channel
+        )
+        if channel is None:
+            print(
+                f"Welcome channel '{self.config.welcome_channel}' not found in guild '{member.guild.name}'."
+            )
+            return
+
+        color = int(self.config.embed_color.lstrip("#"), 16)
+        embed = discord.Embed(
+            title=self.config.welcome_title.format(
+                member=member, member_count=member.guild.member_count
+            ),
+            description=self.config.welcome_message.format(
+                member=member, member_count=member.guild.member_count
+            ),
+            color=color,
+        )
+        embed.set_thumbnail(url=member.display_avatar.url)
+        embed.set_image(url=self.config.banner_url)
+        await channel.send(embed=embed)
+
+    async def on_member_remove(self, member: discord.Member) -> None:
+        channel = discord.utils.get(
+            member.guild.text_channels, name=self.config.leave_channel
+        )
+        if channel is None:
+            print(
+                f"Leave channel '{self.config.leave_channel}' not found in guild '{member.guild.name}'."
+            )
+            return
+
+        color = int(self.config.embed_color.lstrip("#"), 16)
+        embed = discord.Embed(
+            title=self.config.leave_title.format(
+                member=member, member_count=member.guild.member_count
+            ),
+            description=self.config.leave_message.format(
+                member=member, member_count=member.guild.member_count
+            ),
+            color=color,
+        )
+        embed.set_thumbnail(url=member.display_avatar.url)
+        embed.set_image(url=self.config.banner_url)
+        await channel.send(embed=embed)
 
     @tasks.loop(seconds=60)
     async def update_embed(self) -> None:

--- a/bot/config.py
+++ b/bot/config.py
@@ -4,6 +4,12 @@ import configparser
 from dataclasses import dataclass
 from pathlib import Path
 
+BANNER_URL = (
+    "https://cdn.discordapp.com/attachments/1278491203905523854/"
+    "1326757485356253305/MvP_banner_zoomed.jpg?ex=68387ff2&is=68372e72&hm="
+    "8c8f4b0deb6961e58d59bbf06b0ae19dddc47dceded1c431c942bd25ea1a1edd&"
+)
+
 
 @dataclass
 class BotConfig:
@@ -17,6 +23,18 @@ class BotConfig:
     connect_url: str | None = None
     thumbnail_url: str | None = None
     image_url: str | None = None
+    welcome_channel: str = "👋🏻┊arrivers"
+    leave_channel: str = "💻┊dc-logs"
+    embed_color: str = "#ff9d00"
+    banner_url: str = BANNER_URL
+    welcome_title: str = "Welcome {member.name}!"
+    welcome_message: str = (
+        "{member.mention} joined the server. We now have {member_count} members!"
+    )
+    leave_title: str = "{member.name} left."
+    leave_message: str = (
+        "{member.mention} left the server. We now have {member_count} members."
+    )
 
 
 def load_config(path: str | Path = 'config.ini') -> BotConfig:
@@ -35,9 +53,37 @@ def load_config(path: str | Path = 'config.ini') -> BotConfig:
     thumbnail_url = parser.get('discord', 'thumbnail_url', fallback=None)
     image_url = parser.get('discord', 'image_url', fallback=None)
 
+    welcome_channel = parser.get('events', 'welcome_channel', fallback='👋🏻┊arrivers')
+    leave_channel = parser.get('events', 'leave_channel', fallback='💻┊dc-logs')
+    embed_color = parser.get('events', 'embed_color', fallback='#ff9d00')
+    banner_url = parser.get('events', 'banner_url', fallback=BANNER_URL)
+    welcome_title = parser.get('events', 'welcome_title', fallback='Welcome {member.name}!')
+    welcome_message = parser.get('events', 'welcome_message', fallback='{member.mention} joined the server. We now have {member_count} members!')
+    leave_title = parser.get('events', 'leave_title', fallback='{member.name} left.')
+    leave_message = parser.get('events', 'leave_message', fallback='{member.mention} left the server. We now have {member_count} members.')
+
     if token is None:
         raise RuntimeError('Discord token not configured')
     if channel_id is None:
         raise RuntimeError('Discord channel_id not configured')
 
-    return BotConfig(token, channel_id, host, port, username, password, short_server_name, connect_url, thumbnail_url, image_url)
+    return BotConfig(
+        token,
+        channel_id,
+        host,
+        port,
+        username,
+        password,
+        short_server_name,
+        connect_url,
+        thumbnail_url,
+        image_url,
+        welcome_channel,
+        leave_channel,
+        embed_color,
+        banner_url,
+        welcome_title,
+        welcome_message,
+        leave_title,
+        leave_message,
+    )

--- a/config.ini
+++ b/config.ini
@@ -11,3 +11,13 @@ connect_url = https://tinyurl.com/mtamvp1337
 host = 127.0.0.1
 # MTA:SA ASE query port (not the game port)
 port = 22005
+
+[events]
+welcome_channel = 👋🏻┊arrivers
+leave_channel = 💻┊dc-logs
+embed_color = #ff9d00
+banner_url = https://cdn.discordapp.com/attachments/1278491203905523854/1326757485356253305/MvP_banner_zoomed.jpg?ex=68387ff2&is=68372e72&hm=8c8f4b0deb6961e58d59bbf06b0ae19dddc47dceded1c431c942bd25ea1a1edd&
+welcome_title = Welcome {member.name}!
+welcome_message = {member.mention} joined the server. We now have {member_count} members!
+leave_title = {member.name} left.
+leave_message = {member.mention} left the server. We now have {member_count} members.


### PR DESCRIPTION
## Summary
- handle member join and leave events
- provide config fields for embed color, banner, titles and messages
- add `[events]` section to configuration
- document new options in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68813f76d2e08323ace9473ca79e6605